### PR TITLE
fix: element should match elementType

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -403,7 +403,7 @@ var InfiniteScroll = (function(_Component) {
 
 InfiniteScroll.propTypes = {
   children: _propTypes2.default.node.isRequired,
-  element: _propTypes2.default.node,
+  element: _propTypes2.default.elementType,
   hasMore: _propTypes2.default.bool,
   initialLoad: _propTypes2.default.bool,
   isReverse: _propTypes2.default.bool,

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 export default class InfiniteScroll extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    element: PropTypes.node,
+    element: PropTypes.elementType,
     hasMore: PropTypes.bool,
     initialLoad: PropTypes.bool,
     isReverse: PropTypes.bool,


### PR DESCRIPTION
`element` has a wrong propTypes validation.
Really annoying in dev 😄 