### PR TITLE
Detach scroll listeners before attaching more.

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -98,6 +98,7 @@ var InfiniteScroll = (function(_Component) {
     _this.scrollListener = _this.scrollListener.bind(_this);
     _this.eventListenerOptions = _this.eventListenerOptions.bind(_this);
     _this.mousewheelListener = _this.mousewheelListener.bind(_this);
+    _this.scrollParentElement = null;
     return _this;
   }
 
@@ -112,7 +113,7 @@ var InfiniteScroll = (function(_Component) {
     },
     {
       key: 'componentDidUpdate',
-      value: function componentDidUpdate() {
+      value: function componentDidUpdate(prevProps) {
         if (this.props.isReverse && this.loadMore) {
           var parentElement = this.getParentElement(this.scrollComponent);
           parentElement.scrollTop =
@@ -128,7 +129,7 @@ var InfiniteScroll = (function(_Component) {
       key: 'componentWillUnmount',
       value: function componentWillUnmount() {
         this.detachScrollListener();
-        this.detachMousewheelListener();
+        this.scrollParentElement = null;
       }
     },
     {
@@ -174,38 +175,28 @@ var InfiniteScroll = (function(_Component) {
       }
     },
     {
-      key: 'detachMousewheelListener',
-      value: function detachMousewheelListener() {
-        var scrollEl = window;
-        if (this.props.useWindow === false) {
-          scrollEl = this.scrollComponent.parentNode;
-        }
-
-        scrollEl.removeEventListener(
-          'mousewheel',
-          this.mousewheelListener,
-          this.options ? this.options : this.props.useCapture
-        );
-      }
-    },
-    {
       key: 'detachScrollListener',
       value: function detachScrollListener() {
-        var scrollEl = window;
-        if (this.props.useWindow === false) {
-          scrollEl = this.getParentElement(this.scrollComponent);
+        if (!this.scrollParentElement) {
+          return;
         }
 
-        scrollEl.removeEventListener(
+        this.scrollParentElement.removeEventListener(
           'scroll',
           this.scrollListener,
           this.options ? this.options : this.props.useCapture
         );
-        scrollEl.removeEventListener(
+        this.scrollParentElement.removeEventListener(
           'resize',
           this.scrollListener,
           this.options ? this.options : this.props.useCapture
         );
+        this.scrollParentElement.removeEventListener(
+          'mousewheel',
+          this.mousewheelListener,
+          this.options ? this.options : this.props.useCapture
+        );
+        this.scrollParentElement = null;
       }
     },
     {
@@ -239,6 +230,10 @@ var InfiniteScroll = (function(_Component) {
           scrollEl = parentElement;
         }
 
+        if (this.scrollParentElement !== scrollEl) {
+          this.detachScrollListener();
+        }
+
         scrollEl.addEventListener(
           'mousewheel',
           this.mousewheelListener,
@@ -258,6 +253,8 @@ var InfiniteScroll = (function(_Component) {
         if (this.props.initialLoad) {
           this.scrollListener();
         }
+
+        this.scrollParentElement = scrollEl;
       }
     },
     {

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -113,7 +113,7 @@ var InfiniteScroll = (function(_Component) {
     },
     {
       key: 'componentDidUpdate',
-      value: function componentDidUpdate(prevProps) {
+      value: function componentDidUpdate() {
         if (this.props.isReverse && this.loadMore) {
           var parentElement = this.getParentElement(this.scrollComponent);
           parentElement.scrollTop =

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -38,6 +38,7 @@ export default class InfiniteScroll extends Component {
     this.scrollListener = this.scrollListener.bind(this);
     this.eventListenerOptions = this.eventListenerOptions.bind(this);
     this.mousewheelListener = this.mousewheelListener.bind(this);
+    this.scrollParentElement = null;
   }
 
   componentDidMount() {
@@ -60,7 +61,7 @@ export default class InfiniteScroll extends Component {
 
   componentWillUnmount() {
     this.detachScrollListener();
-    this.detachMousewheelListener();
+    this.scrollParentElement = null;
   }
 
   isPassiveSupported() {
@@ -98,35 +99,27 @@ export default class InfiniteScroll extends Component {
     this.defaultLoader = loader;
   }
 
-  detachMousewheelListener() {
-    let scrollEl = window;
-    if (this.props.useWindow === false) {
-      scrollEl = this.scrollComponent.parentNode;
-    }
-
-    scrollEl.removeEventListener(
-      'mousewheel',
-      this.mousewheelListener,
-      this.options ? this.options : this.props.useCapture
-    );
-  }
-
   detachScrollListener() {
-    let scrollEl = window;
-    if (this.props.useWindow === false) {
-      scrollEl = this.getParentElement(this.scrollComponent);
+    if (!this.scrollParentElement) {
+      return;
     }
 
-    scrollEl.removeEventListener(
+    this.scrollParentElement.removeEventListener(
       'scroll',
       this.scrollListener,
       this.options ? this.options : this.props.useCapture
     );
-    scrollEl.removeEventListener(
+    this.scrollParentElement.removeEventListener(
       'resize',
       this.scrollListener,
       this.options ? this.options : this.props.useCapture
     );
+    this.scrollParentElement.removeEventListener(
+      'mousewheel',
+      this.mousewheelListener,
+      this.options ? this.options : this.props.useCapture
+    );
+    this.scrollParentElement = null;
   }
 
   getParentElement(el) {
@@ -154,6 +147,10 @@ export default class InfiniteScroll extends Component {
       scrollEl = parentElement;
     }
 
+    if (this.scrollParentElement !== scrollEl) {
+      this.detachScrollListener();
+    }
+
     scrollEl.addEventListener(
       'mousewheel',
       this.mousewheelListener,
@@ -173,6 +170,8 @@ export default class InfiniteScroll extends Component {
     if (this.props.initialLoad) {
       this.scrollListener();
     }
+
+    this.scrollParentElement = scrollEl;
   }
 
   mousewheelListener(e) {


### PR DESCRIPTION
This addresses an issue where scroll listeners can get leaked if the useWindow or getScrollParent props change. 

To reproduce the original issue:
1. Mount an InfiniteScroll with prop useWindow = true. 
Scroll listeners will be attached to window.
2. Update the useWindow prop to be false. 
Scroll listeners will be attached to the scroll elements parent.
3. Unmount the infiniteScroll.
Scroll listeners will be removed from the scroll elements parent. The scroll listeners attached to window remain - they are leaked.
4. Resize the window. As the scroll listeners are still attached to the window, the scrollListener will fire. As the component is no longer mounted the ref will be invalid, ScrollComponent is null. This causes a null exception.

My change tracks what element currently has scroll listeners attached to it and will the existing scroll listeners before attaching anymore. 