### PR TITLE
Update detachMousewheelListener to call removeEventListener on the right element

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -105,7 +105,7 @@ export default class InfiniteScroll extends Component {
   detachMousewheelListener() {
     let scrollEl = window;
     if (this.props.useWindow === false) {
-      scrollEl = this.scrollComponent.parentNode;
+      scrollEl = this.getParentElement(this.scrollComponent);
     }
 
     scrollEl.removeEventListener(


### PR DESCRIPTION
The 'mousewheel' event is bound to the element that is determined by calling `getParentElement`, however when it is unbound, the element thats being targeted is simply `node.parentElement`. This results in a memory leak when this component is used in conjunction with the `getScrollParent` prop.