### PR TITLE
Pass element to getScrollParent

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -135,7 +135,7 @@ export default class InfiniteScroll extends Component {
 
   getParentElement(el) {
     const scrollParent =
-      this.props.getScrollParent && this.props.getScrollParent();
+      this.props.getScrollParent && this.props.getScrollParent(el);
     if (scrollParent != null) {
       return scrollParent;
     }


### PR DESCRIPTION
This allows callers to do things like:
- simulate the default behavior of the library (`getScrollParent={el => el.parentNode}`)
- perform arbitrary DOM manipulation (`el => el.closest(".container"`)
- use a library like https://github.com/olahol/scrollparent.js to infer from the current element