### PR TITLE
Null check to scroll component

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -49,10 +49,13 @@ export default class InfiniteScroll extends Component {
   componentDidUpdate() {
     if (this.props.isReverse && this.loadMore) {
       const parentElement = this.getParentElement(this.scrollComponent);
-      parentElement.scrollTop =
+
+      if (parentElement) {
+        parentElement.scrollTop =
         parentElement.scrollHeight -
         this.beforeScrollHeight +
         this.beforeScrollTop;
+      }
       this.loadMore = false;
     }
     this.attachScrollListener();
@@ -119,6 +122,10 @@ export default class InfiniteScroll extends Component {
     let scrollEl = window;
     if (this.props.useWindow === false) {
       scrollEl = this.getParentElement(this.scrollComponent);
+    }
+
+    if (!scrollEl) {
+      return;
     }
 
     scrollEl.removeEventListener(


### PR DESCRIPTION
Related to #172, it's possible that `parentElement` appears to be `null` as a result of `getParentElement` of a null `el`. This PR adds null checks to ensure the `parentElement` exist before further calculation.