### PR TITLE
Null element

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -192,6 +192,13 @@ export default class InfiniteScroll extends Component {
     const scrollEl = window;
     const parentNode = this.getParentElement(el);
 
+    // The el could be null due to scroll event being fired while the scroll component no long exists.
+    // Early exit would prevent properties of the null el (and null parent) being accessed in offset
+    // calculation below.
+    if (!el) {
+      return;
+    }
+
     let offset;
     if (this.props.useWindow) {
       const doc =


### PR DESCRIPTION
As discovered in #127, `el` can be null if `scrollComponent` no longer exist at the moment `scrollListener` invoked. This PR handles such case to prevent properties of a null `el` being accessed in the offset calculation 