### PR TITLE
Update peer dependancies to support react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
+    "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Fix for issue https://github.com/danbovey/react-infinite-scroller/issues/272

As react@17 is backward compatible with react@16 the transition should be smooth and it requires only peer dependency update in package.json.