### PR TITLE
fix: added support for snowpack like tools

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 coverage
 test
 .nyc_output


### PR DESCRIPTION
We have enabled support for esm in package.json however `src` directory is missing in npm package.

https://github.com/danbovey/react-infinite-scroller/blob/ba3c5e7b92b19c268073aed69d57fb3328bef6ab/package.json#L6

It causes an issue with the `Snowpack` tool.

<img width="1455" alt="Screenshot 2021-05-02 at 2 30 42 PM" src="https://user-images.githubusercontent.com/8512339/116808209-31bd6e00-ab55-11eb-9f37-283b4cef24e6.png">
