### PR TITLE
Fixes scrollListener accesses properties of null

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -277,6 +277,13 @@ var InfiniteScroll = (function(_Component) {
     {
       key: 'scrollListener',
       value: function scrollListener() {
+        // It appears to be the that ScrollComponent can be already removed at the time this method
+        // is invoked. This early return is needed to prevent the offset calculation from accessing
+        // properties of a null scrollable component. The early return won't alter logic of method
+        // as the element is required to be visible to loadMore.
+        if (!this.scrollComponent) {
+          return;
+        }
         var el = this.scrollComponent;
         var scrollEl = window;
         var parentNode = this.getParentElement(el);

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -188,16 +188,17 @@ export default class InfiniteScroll extends Component {
   }
 
   scrollListener() {
+    // It appears to be the that ScrollComponent can be already removed at the time this method
+    // is invoked. This early return is needed to prevent the offset calculation from accessing
+    // properties of a null scrollable component. The early return won't alter logic of method
+    // as the element is required to be visible to loadMore.
+    if (!this.scrollComponent) {
+      return;
+    }
+
     const el = this.scrollComponent;
     const scrollEl = window;
     const parentNode = this.getParentElement(el);
-
-    // The el could be null due to scroll event being fired while the scroll component no long exists.
-    // Early exit would prevent properties of the null el (and null parent) being accessed in offset
-    // calculation below.
-    if (!el) {
-      return;
-    }
 
     let offset;
     if (this.props.useWindow) {

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -192,6 +192,13 @@ export default class InfiniteScroll extends Component {
     const scrollEl = window;
     const parentNode = this.getParentElement(el);
 
+    // The el could be null due to scroll event being fired while the scroll component no long exists.
+    // Early exit would prevent properties of the null el (and null parent) being accessed in offset
+    // calculation below.
+    if (!el) {
+      return;
+    }
+
     let offset;
     if (this.props.useWindow) {
       const doc =


### PR DESCRIPTION
Change here is already done in

https://github.com/danbovey/react-infinite-scroller/pull/267


this PR is just copying the changes from /src to /dist